### PR TITLE
fix some typos

### DIFF
--- a/docs/basic/export.md
+++ b/docs/basic/export.md
@@ -1,6 +1,6 @@
 # Data Export
 
-The `pyroll-export` package provide several routines for exporting the data in PyRolL's object structure to well known data formats and objects.
+The `pyroll-export` package provides several routines for exporting the data in PyRolL's object structure to well known data formats and objects.
 
 ```{eval-rst}
 .. autofunction:: pyroll.export.to_dict

--- a/docs/basic/report.md
+++ b/docs/basic/report.md
@@ -35,7 +35,7 @@ Currently, four implementations of this hook are predefined.
 :unit_plots_display: displays plots or other graphical presentations of the unit defined by the `unit_plot` hook
 :sequence_units: displays the units a {py:class}`PassSequence` consists of sequentially
 
-Anew new implementation can be defined as follows.
+A new implementation can be defined as follows.
 
 ```python
 import sys

--- a/docs/core/units/index.md
+++ b/docs/core/units/index.md
@@ -9,7 +9,7 @@ The `Unit` class is the base class representing this concept.
 A unit can most abstractly be considered as a black box transforming the state of a profile, thus taking an incoming profile instance, simulating its evolution within the unit and yielding an outgoing profile instance.
 See [The Base Unit Class](base.md) for more detailed information on this concept.
 
-Some units support subdivision into [disk elements](disk_elements.md), to provide finer spacial resolution in rolling resp. length direction.
+Some units support subdivision into [disk elements](disk_elements.md), to provide finer spatial resolution in rolling resp. length direction.
 
 ```{toctree}
 :maxdepth: 4

--- a/docs/core/units/roll_pass/grooves/ovals.md
+++ b/docs/core/units/roll_pass/grooves/ovals.md
@@ -140,6 +140,6 @@ $\delta$ is typically one or two degree larger than 90° for wear reasons.
 $r_3$ is much larger than the other radii.
 
 ```{eval-rst} 
-.. autoclass:: GothicGroove
+.. autoclass:: UpsetOvalGroove
     :members:
 ```

--- a/docs/core/units/transport.md
+++ b/docs/core/units/transport.md
@@ -21,7 +21,7 @@ Transport(
 
 The hook {py:attr}`Transport.duration` is the most important property of a transport.
 It defines the temporal extent of the transport.
-An alternative way of defining the extent is a combination of the spacial extent {py:attr}`Transport.length` and the material flow velocity.
+An alternative way of defining the extent is a combination of the spatial extent {py:attr}`Transport.length` and the material flow velocity.
 
 ```python
 Transport(
@@ -31,7 +31,7 @@ Transport(
 )
 ```
 
-However, this approach may not be appropriate for all transports, as the velocity may not be constant or the spacial extent may be meaningless.
+However, this approach may not be appropriate for all transports, as the velocity may not be constant or the spatial extent may be meaningless.
 Therefore, all models for transport are recommended to be defined at the timescale and independent of the length scale, if possible.
 
 ```{eval-rst} 

--- a/docs/examples/step_by_step/index.md
+++ b/docs/examples/step_by_step/index.md
@@ -91,7 +91,7 @@ A constant flow stress of 100 MPa is given to the profile to enable basic roll f
 
 Now, the pass sequence is defined, although it consists for now of only one roll pass.
 The pass sequence is an instance of the class {py:class}`PassSequence`.
-It's only argument is usually the list of roll passes and transports it shall consist of.
+Its only argument is usually the list of roll passes and transports it shall consist of.
 For now, were are only adding one roll pass, nevertheless we need the pass sequence instance.
 
 ```{literalinclude} input_01.py

--- a/docs/plugins/plugins.json
+++ b/docs/plugins/plugins.json
@@ -72,7 +72,7 @@
     },
     {
       "name": "pyroll-freiberg-flow-stress",
-      "docs": "https://github.com/pyroll-project/pyroll-freiberg-flow-stress/blob/main/docs/index.md",
+      "docs": "https://github.com/pyroll-project/pyroll-freiberg-flow-stress/blob/main/docs/docs.pdf",
       "source": "https://github.com/pyroll-project/pyroll-freiberg-flow-stress",
       "pypi": "https://pypi.org/project/pyroll-freiberg-flow-stress",
       "description": "Provides the Freiberg flow stress approach and a material database."


### PR DESCRIPTION
I have just read the whole doc of PyRolL in the frame of the review for the publication in JOSS:
https://github.com/openjournals/joss-reviews/issues/6200

I have found several typos while reading the text. Here is a quick PR to fix the mistakes.

Apart from that, I think the documentation is pretty well written. It is very easy to read and it allowed me to run the examples, see the results and understand the features of the code.